### PR TITLE
Remove deprecation from gemspec

### DIFF
--- a/declarative_authorization.gemspec
+++ b/declarative_authorization.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.summary = "declarative_authorization is a Rails plugin for maintainable authorization based on readable authorization rules."
   s.email = "sbartsch@tzi.org"
   s.files = %w{CHANGELOG MIT-LICENSE README.rdoc Rakefile authorization_rules.dist.rb garlic_example.rb init.rb} + Dir["app/**/*.rb"] + Dir["app/**/*.erb"] + Dir["config/*"] + Dir["lib/*.rb"] + Dir["lib/**/*.rb"] + Dir["lib/tasks/*"] + Dir["test/*"]
-  s.has_rdoc = true
   s.extra_rdoc_files = ['README.rdoc', 'CHANGELOG']
   s.homepage = %q{http://github.com/stffn/declarative_authorization}
 


### PR DESCRIPTION
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01.
Gem::Specification#has_rdoc= called from /Users/aleksi/.rvm/gems/ree-1.8.7-2011.03/bundler/gems/declarative_authorization-f4bbb0657331/declarative_authorization.gemspec:12
